### PR TITLE
Fixed Path of index.html to work with the default image of Compute Engine

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -33,7 +33,7 @@ DATE=$(date)
 apt-get update
 apt-get install -y nginx
 
-cat <<EOF > /usr/share/nginx/www/index.html
+cat <<EOF > /var/www/html/index.nginx-debian.html
 <html>
 <head>
 <title>Welcome to nginx!</title>


### PR DESCRIPTION
Fixed to work with Debian and combination of nginx default image of Compute Engine.